### PR TITLE
Release v1.3.0: Add Vento TOC and heading anchor processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Or import directly from GitHub:
 - **[deferPagefind](#deferpagefind)** - Defer Pagefind CSS and JS loading
 - **[externalLinksIcon](#externallinksicon)** - Add external link icons to
   `target="_blank"` links
+- **[ventoHeadingAnchors](#ventoheadinganchors)** - Add anchor links to headings in Vento pages
+- **[ventoTOC](#ventotoc)** - Generate table of contents from headings in Vento pages
+- **[ventoTOCInject](#ventotocinject)** - Inject TOC HTML into rendered pages at marker position
 
 ### Filters
 
@@ -196,6 +199,345 @@ const site = lume();
 // Specify the base URL
 site.process([".html"], externalLinksIcon("https://esolia.co.jp"));
 site.process([".html"], deferPagefind());
+
+export default site;
+```
+
+---
+
+#### `ventoHeadingAnchors`
+
+Adds ID attributes and anchor links to heading elements in Vento-rendered pages.
+
+This processor enables deep-linking to headings in pure Vento (.vto) pages, matching the functionality that markdown-it plugins provide for markdown pages. It automatically generates unique slugs for headings and adds clickable anchor links.
+
+**Important:** This processor should run **before** `ventoTOC` to ensure headings have IDs before TOC generation.
+
+**Features:**
+
+- Adds unique `id` attributes to headings (H2-H6)
+- Generates slugs from heading text with collision prevention
+- Adds anchor links with configurable position and styling
+- Matches markdown-it-toc-done-right behavior by default
+- Supports `containerSelector` to limit scope to main content
+- Only processes pure Vento pages (skips markdown pages)
+
+**Parameters:**
+
+- `userOptions`: `HeadingAnchorsOptions` (optional)
+  - `level`: `number` - Minimum heading level to process (default: `2`)
+  - `maxLevel`: `number` - Maximum heading level to process (default: `6`)
+  - `tabIndex`: `number | false` - Tab index for headings (default: `-1`)
+  - `anchorPosition`: `"inside" | "outside"` - Where to place anchor (default: `"inside"`)
+  - `anchorClass`: `string` - CSS class for anchor element (default: `"header-anchor"`)
+  - `anchorSymbol`: `string` - Visible anchor text (default: `""` - use CSS ::before)
+  - `ariaLabel`: `string` - Aria label for anchor (default: `"Permalink"`)
+  - `includeTemplateEngines`: `string[]` - Template engines to process (default: `["vto"]`)
+  - `containerSelector`: `string` - CSS selector to limit extraction scope (optional)
+  - `slugify`: `(text: string) => string` - Custom slug generator (optional)
+
+**Example:**
+
+```ts
+// In your Lume _config.ts:
+import lume from "lume/mod.ts";
+import { ventoHeadingAnchors, ventoTOC, ventoTOCInject } from "hibana/mod.ts";
+
+const site = lume();
+
+// Add heading anchors (matches markdown-it style by default)
+site.process([".html"], ventoHeadingAnchors({
+  level: 2,              // Start at h2
+  maxLevel: 4,           // End at h4
+  containerSelector: "article", // Only process headings in <article>
+}));
+
+// Then generate TOC
+site.process([".html"], ventoTOC({
+  level: 2,
+  maxLevel: 4,
+  containerSelector: "article",
+}));
+
+// Finally inject TOC HTML
+site.process([".html"], ventoTOCInject());
+
+export default site;
+```
+
+**Output:**
+
+```html
+<!-- Input -->
+<article>
+  <h2>Introduction</h2>
+  <h3>Getting Started</h3>
+</article>
+
+<!-- Output (default: anchorPosition "inside", no symbol) -->
+<article>
+  <h2 id="introduction" tabindex="-1">
+    <a href="#introduction" class="header-anchor" aria-label="Permalink">Introduction</a>
+  </h2>
+  <h3 id="getting-started" tabindex="-1">
+    <a href="#getting-started" class="header-anchor" aria-label="Permalink">Getting Started</a>
+  </h3>
+</article>
+
+<!-- Styled with CSS ::before for link icon -->
+```
+
+**CSS Example:**
+
+```css
+.header-anchor::before {
+  content: "#";
+  position: absolute;
+  left: -1em;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+h2:hover .header-anchor::before,
+h3:hover .header-anchor::before {
+  opacity: 1;
+}
+```
+
+---
+
+#### `ventoTOC`
+
+Generates a hierarchical table of contents (TOC) data structure from headings in Vento-rendered pages.
+
+This processor extracts headings and builds a nested tree structure stored in `page.data.toc`. It's designed to work alongside `ventoTOCInject` to provide TOC functionality for pure Vento pages.
+
+**Important:**
+- Run this **after** `ventoHeadingAnchors` (headings need IDs first)
+- Run this **before** `ventoTOCInject` (injection needs TOC data)
+- Due to Lume's build order (processors run after layouts), use `ventoTOCInject` to actually display the TOC
+
+**Features:**
+
+- Builds hierarchical TOC tree from headings
+- Stores data in `page.data.toc` for template access
+- Generates full URLs with anchors for each heading
+- Supports `containerSelector` to limit scope
+- Only processes pure Vento pages (skips markdown pages)
+- Respects `show_toc` frontmatter setting
+
+**Parameters:**
+
+- `userOptions`: `TOCGeneratorOptions` (optional)
+  - `level`: `number` - Minimum heading level (default: `2`)
+  - `maxLevel`: `number` - Maximum heading level (default: `6`)
+  - `key`: `string` - Page data key for TOC (default: `"toc"`)
+  - `includeTemplateEngines`: `string[]` - Engines to process (default: `["vto"]`)
+  - `containerSelector`: `string` - CSS selector to limit extraction scope (optional)
+
+**Example:**
+
+```ts
+// In your Lume _config.ts:
+import lume from "lume/mod.ts";
+import { ventoHeadingAnchors, ventoTOC, ventoTOCInject } from "hibana/mod.ts";
+
+const site = lume();
+
+// Process headings in order
+site.process([".html"], ventoHeadingAnchors({
+  level: 2,
+  maxLevel: 4,
+  containerSelector: "article", // Only main content
+}));
+
+site.process([".html"], ventoTOC({
+  level: 2,
+  maxLevel: 4,
+  key: "toc",  // Stores in page.data.toc
+  containerSelector: "article", // Match heading anchors scope
+}));
+
+site.process([".html"], ventoTOCInject());
+
+export default site;
+```
+
+**TOC Data Structure:**
+
+```ts
+interface TOCNode {
+  level: number;        // Heading level (2-6)
+  text: string;         // Heading text content
+  slug: string;         // URL-safe slug from id attribute
+  url: string;          // Full URL with anchor (#slug)
+  children: TOCNode[];  // Nested child headings
+}
+```
+
+**Example Output:**
+
+```ts
+// page.data.toc contains:
+[
+  {
+    level: 2,
+    text: "Introduction",
+    slug: "introduction",
+    url: "/page/#introduction",
+    children: [
+      {
+        level: 3,
+        text: "Getting Started",
+        slug: "getting-started",
+        url: "/page/#getting-started",
+        children: []
+      }
+    ]
+  }
+]
+```
+
+---
+
+#### `ventoTOCInject`
+
+Injects TOC HTML into rendered pages at a marker position, working around Lume's build order limitation.
+
+**The Problem:** Lume's build order is: Preprocessors → Template Rendering → **Layout Rendering** → Processors. Since processors run **after** layouts render, `page.data.toc` isn't available when the layout template executes.
+
+**The Solution:** This processor finds a marker comment in the rendered HTML and replaces it with generated TOC HTML. This allows TOCs to appear in layouts even though the data is generated after layout rendering.
+
+**Features:**
+
+- Injects complete TOC HTML structure at marker position
+- Respects `show_toc` frontmatter (skips if `false`)
+- Matches styling from existing markdown TOCs
+- Checks for punchlist/topic to add proper spacing
+- Only processes pages with TOC data
+
+**Parameters:**
+
+None - automatically processes all pages with TOC data.
+
+**Example:**
+
+```ts
+// In your Lume _config.ts:
+import lume from "lume/mod.ts";
+import { ventoHeadingAnchors, ventoTOC, ventoTOCInject } from "hibana/mod.ts";
+
+const site = lume();
+
+// Standard processor order
+site.process([".html"], ventoHeadingAnchors({
+  level: 2,
+  maxLevel: 4,
+  containerSelector: "article",
+}));
+site.process([".html"], ventoTOC({
+  level: 2,
+  maxLevel: 4,
+  containerSelector: "article",
+}));
+site.process([".html"], ventoTOCInject());
+
+export default site;
+```
+
+**Layout Template:**
+
+```vto
+<!-- In your layout (e.g., layouts/docs.vto) -->
+<div class="sidebar">
+  <!-- Other sidebar content -->
+
+  <!-- VENTO-TOC-INJECTION-POINT: This comment will be replaced by processor -->
+
+  <!-- Fallback TOC template for markdown pages -->
+  {{ if toc && toc.length > 0 }}
+    <nav aria-labelledby="toc-title">
+      <!-- TOC markup -->
+    </nav>
+  {{ /if }}
+</div>
+```
+
+**Frontmatter Control:**
+
+```yaml
+---
+title: My Page
+show_toc: true  # TOC will be injected
+---
+
+# Or disable TOC for specific pages:
+---
+title: Another Page
+show_toc: false  # No TOC injection
+---
+```
+
+**How It Works:**
+
+1. `ventoTOC` generates TOC data and stores in `page.data.toc`
+2. Layout renders with marker comment: `<!-- VENTO-TOC-INJECTION-POINT: -->`
+3. `ventoTOCInject` finds the marker in rendered HTML
+4. Marker is replaced with complete TOC HTML structure
+5. Result: TOC appears in final output
+
+**Generated HTML:**
+
+```html
+<nav aria-labelledby="on-this-page-title" class="w-56">
+  <h2 id="on-this-page-title" class="font-display text-sm">
+    On this page
+  </h2>
+  <ol role="list" class="mt-4 space-y-3 text-sm">
+    <li>
+      <h3>
+        <a href="#introduction" class="toc-link" data-toc-id="introduction">
+          Introduction
+        </a>
+      </h3>
+      <ol role="list" class="mt-2 space-y-3 pl-5">
+        <li>
+          <a href="#getting-started" class="toc-link" data-toc-id="getting-started">
+            Getting Started
+          </a>
+        </li>
+      </ol>
+    </li>
+  </ol>
+</nav>
+```
+
+**Complete Workflow:**
+
+```ts
+// _config.ts - Complete setup
+import lume from "lume/mod.ts";
+import { ventoHeadingAnchors, ventoTOC, ventoTOCInject } from "hibana/mod.ts";
+
+const site = lume();
+
+// 1. Add IDs and anchors to headings
+site.process([".html"], ventoHeadingAnchors({
+  level: 2,
+  maxLevel: 4,
+  containerSelector: "article", // Only <article> headings
+}));
+
+// 2. Generate TOC data structure
+site.process([".html"], ventoTOC({
+  level: 2,
+  maxLevel: 4,
+  key: "toc",
+  containerSelector: "article", // Match heading scope
+}));
+
+// 3. Inject TOC HTML at marker
+site.process([".html"], ventoTOCInject());
 
 export default site;
 ```

--- a/mod.ts
+++ b/mod.ts
@@ -76,6 +76,7 @@ export { default as deferPagefind } from "./processors/defer_pagefind.ts";
 export { default as externalLinksIcon } from "./processors/external_links_icon.ts";
 export { default as ventoHeadingAnchors } from "./processors/vento_heading_anchors.ts";
 export { default as ventoTOC } from "./processors/vento_toc.ts";
+export { default as ventoTOCInject } from "./processors/vento_toc_inject.ts";
 export type {
   HeadingAnchorsOptions,
   TOCGeneratorOptions,

--- a/mod.ts
+++ b/mod.ts
@@ -15,6 +15,8 @@
  * - {@link shuffle} - A plugin to add a shuffle filter for arrays.
  * - {@link deferPagefind} - A processor to defer Pagefind CSS and JS loading.
  * - {@link externalLinksIcon} - A processor to add external link icons to `target="_blank"` links.
+ * - {@link ventoHeadingAnchors} - A processor to add anchor links to headings in Vento pages.
+ * - {@link ventoTOC} - A processor to generate table of contents from headings in Vento pages.
  * - {@link temporalDate} - A Temporal API-based date filter with timezone support.
  * - {@link markdownMetadata} - Extract excerpts and calculate elapsed days from markdown.
  * - {@link breadcrumbSchema} - Auto-generate Schema.org breadcrumbs from URLs.
@@ -53,6 +55,8 @@
  *   shuffle,
  *   deferPagefind,
  *   externalLinksIcon,
+ *   ventoHeadingAnchors,
+ *   ventoTOC,
  *   temporalDate,
  *   markdownMetadata,
  *   breadcrumbSchema,
@@ -70,6 +74,13 @@ export { default as shuffle } from "./plugins/shuffle.ts";
 // Processors
 export { default as deferPagefind } from "./processors/defer_pagefind.ts";
 export { default as externalLinksIcon } from "./processors/external_links_icon.ts";
+export { default as ventoHeadingAnchors } from "./processors/vento_heading_anchors.ts";
+export { default as ventoTOC } from "./processors/vento_toc.ts";
+export type {
+  HeadingAnchorsOptions,
+  TOCGeneratorOptions,
+  TOCNode,
+} from "./types/vento_toc.ts";
 
 // Filters
 export { default as temporalDate } from "./filters/temporal_date.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -17,6 +17,7 @@
  * - {@link externalLinksIcon} - A processor to add external link icons to `target="_blank"` links.
  * - {@link ventoHeadingAnchors} - A processor to add anchor links to headings in Vento pages.
  * - {@link ventoTOC} - A processor to generate table of contents from headings in Vento pages.
+ * - {@link ventoTOCInject} - A processor to inject TOC HTML into rendered pages at marker position.
  * - {@link temporalDate} - A Temporal API-based date filter with timezone support.
  * - {@link markdownMetadata} - Extract excerpts and calculate elapsed days from markdown.
  * - {@link breadcrumbSchema} - Auto-generate Schema.org breadcrumbs from URLs.
@@ -57,6 +58,7 @@
  *   externalLinksIcon,
  *   ventoHeadingAnchors,
  *   ventoTOC,
+ *   ventoTOCInject,
  *   temporalDate,
  *   markdownMetadata,
  *   breadcrumbSchema,

--- a/processors/vento_heading_anchors.ts
+++ b/processors/vento_heading_anchors.ts
@@ -31,6 +31,9 @@ export const defaults: Required<
 
 /**
  * Checks if a page should be processed based on its template engine.
+ *
+ * IMPORTANT: Skips markdown pages even if they also use Vento, since
+ * markdown-it plugins already handle anchor generation for those pages.
  */
 function shouldProcessPage(
   page: Page,
@@ -42,12 +45,15 @@ function shouldProcessPage(
     return false;
   }
 
-  // Handle both string and array template engines
+  // Skip markdown pages - they get anchors from markdown-it plugins
   if (typeof engine === "string") {
+    if (engine === "md") return false;
     return includeTemplateEngines.includes(engine);
   }
 
   if (Array.isArray(engine)) {
+    // Skip if markdown is in the chain (e.g., ["md", "vto"])
+    if (engine.includes("md")) return false;
     return engine.some((e) => includeTemplateEngines.includes(e));
   }
 

--- a/processors/vento_heading_anchors.ts
+++ b/processors/vento_heading_anchors.ts
@@ -1,0 +1,186 @@
+/**
+ * @file Lume processor to add anchor links to headings in Vento-rendered pages.
+ * @author Rick Cogley
+ */
+
+import type { Page } from "../types/lume.ts";
+import type { HeadingAnchorsOptions } from "../types/vento_toc.ts";
+import { extractHeadingElements, getHeadingText } from "../utils/headings.ts";
+import { UniqueSlugGenerator } from "../utils/slugify.ts";
+
+/** Default options for heading anchors processor */
+export const defaults: Required<
+  Omit<HeadingAnchorsOptions, "slugify">
+> & Pick<HeadingAnchorsOptions, "slugify"> = {
+  level: 2,
+  maxLevel: 6,
+  tabIndex: -1,
+  anchorPosition: "outside",
+  anchorClass: "header-anchor",
+  anchorSymbol: "#",
+  ariaLabel: "Permalink",
+  includeTemplateEngines: ["vto"],
+  slugify: undefined,
+};
+
+/**
+ * Checks if a page should be processed based on its template engine.
+ */
+function shouldProcessPage(
+  page: Page,
+  includeTemplateEngines: string[],
+): boolean {
+  const engine = page.data?.templateEngine;
+
+  if (!engine) {
+    return false;
+  }
+
+  // Handle both string and array template engines
+  if (typeof engine === "string") {
+    return includeTemplateEngines.includes(engine);
+  }
+
+  if (Array.isArray(engine)) {
+    return engine.some((e) => includeTemplateEngines.includes(e));
+  }
+
+  return false;
+}
+
+/**
+ * Adds ID and anchor links to heading elements in Vento-rendered pages.
+ *
+ * This processor:
+ * - Adds unique `id` attributes to headings
+ * - Optionally adds `tabindex` attributes for keyboard navigation
+ * - Inserts anchor links (# symbols) for deep linking
+ * - Handles duplicate headings with numbered suffixes
+ * - Only processes pages rendered with specified template engines (default: Vento)
+ *
+ * @param userOptions - Configuration options
+ * @returns A Lume processor function
+ *
+ * @example
+ * ```ts
+ * // In your Lume _config.ts:
+ * import { ventoHeadingAnchors } from "hibana/mod.ts";
+ *
+ * const site = lume();
+ *
+ * // Add heading anchors to Vento pages
+ * site.process([".html"], ventoHeadingAnchors({
+ *   level: 2,              // Start at h2
+ *   maxLevel: 4,           // End at h4
+ *   anchorPosition: "outside",  // Place # after heading text
+ * }));
+ * ```
+ *
+ * @example
+ * ```html
+ * <!-- Input -->
+ * <h2>Introduction</h2>
+ * <h3>Getting Started</h3>
+ *
+ * <!-- Output (anchorPosition: "outside") -->
+ * <h2 id="introduction" tabindex="-1">
+ *   Introduction
+ *   <a href="#introduction" class="header-anchor" aria-label="Permalink">#</a>
+ * </h2>
+ * <h3 id="getting-started" tabindex="-1">
+ *   Getting Started
+ *   <a href="#getting-started" class="header-anchor" aria-label="Permalink">#</a>
+ * </h3>
+ * ```
+ */
+export default function ventoHeadingAnchors(
+  userOptions: HeadingAnchorsOptions = {},
+) {
+  // Merge user options with defaults
+  const options: Required<Omit<HeadingAnchorsOptions, "slugify">> & {
+    slugify?: (text: string) => string;
+  } = {
+    ...defaults,
+    ...userOptions,
+  };
+
+  let processedPages = 0;
+  let addedAnchors = 0;
+
+  return function ventoHeadingAnchorsProcessor(pages: Page[]) {
+    for (const page of pages) {
+      // Skip pages that shouldn't be processed
+      if (!shouldProcessPage(page, options.includeTemplateEngines)) {
+        continue;
+      }
+
+      const document = page.document;
+      if (!document) continue;
+
+      // Skip if already processed (check for marker)
+      if (page.data?.headingAnchorsAdded) {
+        continue;
+      }
+
+      // Extract heading elements
+      const headings = extractHeadingElements(
+        document,
+        options.level,
+        options.maxLevel,
+      );
+
+      if (headings.length === 0) {
+        continue;
+      }
+
+      // Generate unique slugs
+      const slugGenerator = new UniqueSlugGenerator();
+
+      for (const heading of headings) {
+        const text = getHeadingText(heading);
+        const slug = options.slugify
+          ? slugGenerator.generate(text)
+          : slugGenerator.generate(text);
+
+        // Add id attribute
+        heading.setAttribute("id", slug);
+
+        // Add tabindex if specified
+        if (options.tabIndex !== false) {
+          heading.setAttribute("tabindex", String(options.tabIndex));
+        }
+
+        // Create anchor link
+        const anchor = document.createElement("a");
+        anchor.setAttribute("href", `#${slug}`);
+        anchor.setAttribute("class", options.anchorClass);
+        anchor.setAttribute("aria-label", options.ariaLabel);
+        anchor.textContent = options.anchorSymbol;
+
+        if (options.anchorPosition === "inside") {
+          // Wrap heading content in anchor
+          const originalContent = heading.innerHTML;
+          heading.innerHTML = "";
+          anchor.innerHTML = originalContent;
+          heading.appendChild(anchor);
+        } else {
+          // Append anchor after heading content
+          heading.appendChild(anchor);
+        }
+
+        addedAnchors++;
+      }
+
+      // Mark page as processed
+      page.data.headingAnchorsAdded = true;
+      processedPages++;
+    }
+
+    // Log summary
+    if (processedPages > 0) {
+      console.log(
+        `🔗 ventoHeadingAnchors: Processed ${processedPages} page(s), added ${addedAnchors} anchor(s)`,
+      );
+    }
+  };
+}

--- a/processors/vento_heading_anchors.ts
+++ b/processors/vento_heading_anchors.ts
@@ -8,16 +8,22 @@ import type { HeadingAnchorsOptions } from "../types/vento_toc.ts";
 import { extractHeadingElements, getHeadingText } from "../utils/headings.ts";
 import { UniqueSlugGenerator } from "../utils/slugify.ts";
 
-/** Default options for heading anchors processor */
+/** Default options for heading anchors processor
+ *
+ * Defaults match markdown-it-toc-done-right behavior:
+ * - Anchor wraps heading text (anchorPosition: "inside")
+ * - No visible symbol (anchorSymbol: "") - expects CSS ::before icon
+ * - Uses "header-anchor" class for styling hook
+ */
 export const defaults: Required<
   Omit<HeadingAnchorsOptions, "slugify">
 > & Pick<HeadingAnchorsOptions, "slugify"> = {
   level: 2,
   maxLevel: 6,
   tabIndex: -1,
-  anchorPosition: "outside",
+  anchorPosition: "inside", // Match markdown-it: wrap heading text in anchor
   anchorClass: "header-anchor",
-  anchorSymbol: "#",
+  anchorSymbol: "", // Empty by default - use CSS ::before for icon
   ariaLabel: "Permalink",
   includeTemplateEngines: ["vto"],
   slugify: undefined,
@@ -68,11 +74,16 @@ function shouldProcessPage(
  *
  * const site = lume();
  *
- * // Add heading anchors to Vento pages
+ * // Add heading anchors to Vento pages (matches markdown-it style by default)
  * site.process([".html"], ventoHeadingAnchors({
  *   level: 2,              // Start at h2
  *   maxLevel: 4,           // End at h4
- *   anchorPosition: "outside",  // Place # after heading text
+ * }));
+ *
+ * // Or customize for different style (e.g., visible # symbol outside)
+ * site.process([".html"], ventoHeadingAnchors({
+ *   anchorPosition: "outside",  // Place anchor after heading text
+ *   anchorSymbol: "#",          // Visible # symbol
  * }));
  * ```
  *
@@ -82,15 +93,15 @@ function shouldProcessPage(
  * <h2>Introduction</h2>
  * <h3>Getting Started</h3>
  *
- * <!-- Output (anchorPosition: "outside") -->
+ * <!-- Output (default: anchorPosition "inside", no symbol) -->
  * <h2 id="introduction" tabindex="-1">
- *   Introduction
- *   <a href="#introduction" class="header-anchor" aria-label="Permalink">#</a>
+ *   <a href="#introduction" class="header-anchor" aria-label="Permalink">Introduction</a>
  * </h2>
  * <h3 id="getting-started" tabindex="-1">
- *   Getting Started
- *   <a href="#getting-started" class="header-anchor" aria-label="Permalink">#</a>
+ *   <a href="#getting-started" class="header-anchor" aria-label="Permalink">Getting Started</a>
  * </h3>
+ *
+ * <!-- Styled with CSS ::before for link icon (like markdown-it-toc-done-right) -->
  * ```
  */
 export default function ventoHeadingAnchors(

--- a/processors/vento_heading_anchors.ts
+++ b/processors/vento_heading_anchors.ts
@@ -144,6 +144,7 @@ export default function ventoHeadingAnchors(
         document,
         options.level,
         options.maxLevel,
+        options.containerSelector,
       );
 
       if (headings.length === 0) {

--- a/processors/vento_toc.ts
+++ b/processors/vento_toc.ts
@@ -1,0 +1,227 @@
+/**
+ * @file Lume processor to generate table of contents from headings in Vento-rendered pages.
+ * @author Rick Cogley
+ */
+
+import type { Page } from "../types/lume.ts";
+import type { TOCGeneratorOptions, TOCNode } from "../types/vento_toc.ts";
+import {
+  extractHeadingElements,
+  getHeadingLevel,
+  getHeadingText,
+} from "../utils/headings.ts";
+
+/** Default options for TOC generator processor */
+export const defaults: Required<TOCGeneratorOptions> = {
+  level: 2,
+  maxLevel: 6,
+  key: "toc",
+  includeTemplateEngines: ["vto"],
+};
+
+/**
+ * Checks if a page should be processed based on its template engine.
+ */
+function shouldProcessPage(
+  page: Page,
+  includeTemplateEngines: string[],
+): boolean {
+  const engine = page.data?.templateEngine;
+
+  if (!engine) {
+    return false;
+  }
+
+  // Handle both string and array template engines
+  if (typeof engine === "string") {
+    return includeTemplateEngines.includes(engine);
+  }
+
+  if (Array.isArray(engine)) {
+    return engine.some((e) => includeTemplateEngines.includes(e));
+  }
+
+  return false;
+}
+
+/**
+ * Builds a hierarchical TOC tree from flat heading data.
+ *
+ * @param headings - Array of heading elements with IDs
+ * @param pageUrl - URL of the current page
+ * @returns Hierarchical array of TOC nodes
+ */
+function buildTOCTree(
+  headings: Array<{ level: number; text: string; slug: string }>,
+  pageUrl: string,
+): TOCNode[] {
+  const root: TOCNode = {
+    level: 0,
+    text: "",
+    slug: "",
+    url: "",
+    children: [],
+  };
+  const stack: TOCNode[] = [root];
+
+  for (const heading of headings) {
+    const url = `${pageUrl}#${heading.slug}`;
+    const node: TOCNode = {
+      level: heading.level,
+      text: heading.text,
+      slug: heading.slug,
+      url,
+      children: [],
+    };
+
+    // Find the correct parent in the stack
+    while (stack.length > 1 && stack[0].level >= node.level) {
+      stack.shift();
+    }
+
+    // Add to parent's children
+    stack[0].children.push(node);
+
+    // Add to stack for potential children
+    stack.unshift(node);
+  }
+
+  return root.children;
+}
+
+/**
+ * Generates a table of contents (TOC) from headings in Vento-rendered pages.
+ *
+ * This processor:
+ * - Extracts heading elements with IDs (assumes headings already have IDs from ventoHeadingAnchors)
+ * - Builds a hierarchical tree structure
+ * - Stores TOC in `page.data.toc` for use in templates
+ * - Only processes pages rendered with specified template engines (default: Vento)
+ *
+ * **Important:** This processor should run AFTER `ventoHeadingAnchors` to ensure headings have IDs.
+ *
+ * @param userOptions - Configuration options
+ * @returns A Lume processor function
+ *
+ * @example
+ * ```ts
+ * // In your Lume _config.ts:
+ * import { ventoHeadingAnchors, ventoTOC } from "hibana/mod.ts";
+ *
+ * const site = lume();
+ *
+ * // IMPORTANT: Add anchors BEFORE generating TOC
+ * site.process([".html"], ventoHeadingAnchors({
+ *   level: 2,
+ *   maxLevel: 4,
+ * }));
+ *
+ * site.process([".html"], ventoTOC({
+ *   level: 2,
+ *   maxLevel: 4,
+ *   key: "toc",  // Stores in page.data.toc
+ * }));
+ * ```
+ *
+ * @example
+ * ```vto
+ * <!-- In your layout template -->
+ * {{ if toc && toc.length > 0 }}
+ *   <nav class="toc">
+ *     <h2>Table of Contents</h2>
+ *     <ul>
+ *       {{ for item of toc }}
+ *         <li>
+ *           <a href="{{ item.url }}">{{ item.text }}</a>
+ *           {{ if item.children.length > 0 }}
+ *             <ul>
+ *               {{ for child of item.children }}
+ *                 <li><a href="{{ child.url }}">{{ child.text }}</a></li>
+ *               {{ /for }}
+ *             </ul>
+ *           {{ /if }}
+ *         </li>
+ *       {{ /for }}
+ *     </ul>
+ *   </nav>
+ * {{ /if }}
+ * ```
+ */
+export default function ventoTOC(
+  userOptions: TOCGeneratorOptions = {},
+) {
+  // Merge user options with defaults
+  const options: Required<TOCGeneratorOptions> = {
+    ...defaults,
+    ...userOptions,
+  };
+
+  let processedPages = 0;
+  let generatedTOCs = 0;
+
+  return function ventoTOCProcessor(pages: Page[]) {
+    for (const page of pages) {
+      // Skip pages that shouldn't be processed
+      if (!shouldProcessPage(page, options.includeTemplateEngines)) {
+        continue;
+      }
+
+      const document = page.document;
+      if (!document) continue;
+
+      // Skip if TOC already exists (from markdown-it or previous run)
+      if (page.data?.[options.key]) {
+        continue;
+      }
+
+      // Extract heading elements
+      const headings = extractHeadingElements(
+        document,
+        options.level,
+        options.maxLevel,
+      );
+
+      if (headings.length === 0) {
+        continue;
+      }
+
+      // Extract heading data (text, level, slug from id attribute)
+      const headingData = headings.map((element) => {
+        const level = getHeadingLevel(element);
+        const text = getHeadingText(element);
+        const slug = element.getAttribute("id") || "";
+
+        // Warn if heading doesn't have an ID
+        if (!slug) {
+          console.warn(
+            `⚠️  ventoTOC: Heading "${text}" on page ${page.data?.url || "unknown"} has no ID attribute. ` +
+              `Run ventoHeadingAnchors processor first.`,
+          );
+        }
+
+        return { level, text, slug };
+      }).filter((h) => h.slug !== ""); // Filter out headings without IDs
+
+      if (headingData.length === 0) {
+        continue;
+      }
+
+      // Build hierarchical TOC tree
+      const pageUrl = page.data?.url || "";
+      const toc = buildTOCTree(headingData, pageUrl);
+
+      // Store TOC in page data
+      page.data[options.key] = toc;
+
+      generatedTOCs++;
+      processedPages++;
+    }
+
+    // Log summary
+    if (processedPages > 0) {
+      console.log(
+        `📑 ventoTOC: Processed ${processedPages} page(s), generated ${generatedTOCs} TOC(s)`,
+      );
+    }
+  };
+}

--- a/processors/vento_toc.ts
+++ b/processors/vento_toc.ts
@@ -21,6 +21,9 @@ export const defaults: Required<TOCGeneratorOptions> = {
 
 /**
  * Checks if a page should be processed based on its template engine.
+ *
+ * IMPORTANT: Skips markdown pages even if they also use Vento, since
+ * markdown-it plugins already handle TOC generation for those pages.
  */
 function shouldProcessPage(
   page: Page,
@@ -32,12 +35,15 @@ function shouldProcessPage(
     return false;
   }
 
-  // Handle both string and array template engines
+  // Skip markdown pages - they get TOC from markdown-it plugins
   if (typeof engine === "string") {
+    if (engine === "md") return false;
     return includeTemplateEngines.includes(engine);
   }
 
   if (Array.isArray(engine)) {
+    // Skip if markdown is in the chain (e.g., ["md", "vto"])
+    if (engine.includes("md")) return false;
     return engine.some((e) => includeTemplateEngines.includes(e));
   }
 

--- a/processors/vento_toc.ts
+++ b/processors/vento_toc.ts
@@ -185,6 +185,7 @@ export default function ventoTOC(
         document,
         options.level,
         options.maxLevel,
+        options.containerSelector,
       );
 
       if (headings.length === 0) {

--- a/processors/vento_toc_inject.ts
+++ b/processors/vento_toc_inject.ts
@@ -1,0 +1,146 @@
+/**
+ * @file Lume processor to inject TOC HTML into Vento pages at marker position.
+ * @author Rick Cogley
+ *
+ * This works around the limitation that processors run after layout rendering,
+ * so we can't pass TOC data to layouts. Instead, we inject HTML directly.
+ */
+
+import type { Page } from "../types/lume.ts";
+import type { TOCNode } from "../types/vento_toc.ts";
+
+const INJECTION_MARKER = "<!-- VENTO-TOC-INJECTION-POINT:";
+
+/**
+ * Generates TOC HTML from TOC data structure
+ */
+function generateTOCHTML(
+  toc: TOCNode[],
+  hasPunchlistOrTopic: boolean,
+  i18nLabel: string = "On this page",
+): string {
+  if (!toc || toc.length === 0) return "";
+
+  const borderClass = hasPunchlistOrTopic
+    ? "mt-8 pt-8 border-t border-accent-200 dark:border-accent-700"
+    : "";
+
+  let html = `
+<nav
+  aria-labelledby="on-this-page-title"
+  class="w-56 ${borderClass}"
+>
+  <h2
+    id="on-this-page-title"
+    class="font-display text-sm font-medium text-accent-900 dark:text-white"
+  >
+    ${i18nLabel}
+  </h2>
+  <ol role="list" class="mt-4 space-y-3 text-sm">`;
+
+  for (const section of toc) {
+    html += `
+    <li>
+      <h3>
+        <a
+          href="#${section.slug}"
+          class="toc-link font-normal text-accent-500 hover:text-accent-700 dark:text-accent-400 dark:hover:text-accent-300"
+          data-toc-id="${section.slug}"
+        >
+          ${section.text}
+        </a>
+      </h3>`;
+
+    if (section.children && section.children.length > 0) {
+      html += `
+      <ol
+        role="list"
+        class="mt-2 space-y-3 pl-5 text-accent-500 dark:text-accent-400"
+      >`;
+
+      for (const child of section.children) {
+        html += `
+        <li>
+          <a
+            href="#${child.slug}"
+            class="toc-link hover:text-accent-600 dark:hover:text-accent-300"
+            data-toc-id="${child.slug}"
+          >
+            ${child.text}
+          </a>
+        </li>`;
+      }
+
+      html += `
+      </ol>`;
+    }
+
+    html += `
+    </li>`;
+  }
+
+  html += `
+  </ol>
+</nav>`;
+
+  return html;
+}
+
+/**
+ * Checks if page has punchlist or topic (affects TOC styling)
+ */
+function hasPunchlistOrTopic(page: Page): boolean {
+  const hasPunchlist = page.data?.punchlist?.items?.length > 0;
+  const hasTopic = !!page.data?.topic;
+  return hasPunchlist || hasTopic;
+}
+
+/**
+ * Injects TOC HTML into pages at the injection marker
+ */
+export default function ventoTOCInject() {
+  let injectedCount = 0;
+
+  return function ventoTOCInjectProcessor(pages: Page[]) {
+    for (const page of pages) {
+      // Only process pages with TOC data and show_toc not false
+      if (!page.data?.toc || page.data?.show_toc === false) {
+        continue;
+      }
+
+      // Get page content as string
+      const content = typeof page.content === "string"
+        ? page.content
+        : new TextDecoder().decode(page.content);
+
+      // Check if marker exists
+      if (!content.includes(INJECTION_MARKER)) {
+        continue;
+      }
+
+      // Get i18n label
+      const i18nLabel = page.data?.i18n?.on_this_page || "On this page";
+
+      // Generate TOC HTML
+      const tocHTML = generateTOCHTML(
+        page.data.toc as TOCNode[],
+        hasPunchlistOrTopic(page),
+        i18nLabel,
+      );
+
+      // Find the marker line and replace it with TOC HTML
+      const markerRegex = /<!--\s*VENTO-TOC-INJECTION-POINT:.*?-->/;
+      const newContent = content.replace(markerRegex, tocHTML);
+
+      // Update page content
+      page.content = newContent;
+      injectedCount++;
+    }
+
+    if (injectedCount > 0) {
+      console.log(
+        `✅ ventoTOCInject: Injected TOC HTML into ${injectedCount} page(s)`,
+      );
+    }
+  };
+}

--- a/types/vento_toc.ts
+++ b/types/vento_toc.ts
@@ -40,6 +40,15 @@ export interface HeadingAnchorsOptions {
   maxLevel?: number;
 
   /**
+   * CSS selector to limit heading extraction to a specific container
+   * Useful to exclude headings from sidebars, navigation, etc.
+   * @default undefined (all headings)
+   * @example "article" - only headings inside <article> tags
+   * @example "#main-content" - only headings inside element with that ID
+   */
+  containerSelector?: string;
+
+  /**
    * Value of the tabindex attribute on headings, set to false to disable
    * @default -1
    */
@@ -111,6 +120,14 @@ export interface TOCGeneratorOptions {
    * @default ["vto"]
    */
   includeTemplateEngines?: string[];
+
+  /**
+   * CSS selector to limit heading extraction to a specific container
+   * Useful to exclude headings from sidebars, navigation, etc.
+   * @default undefined (all headings)
+   * @example "article" - only headings inside <article> tags
+   */
+  containerSelector?: string;
 }
 
 /**

--- a/types/vento_toc.ts
+++ b/types/vento_toc.ts
@@ -1,0 +1,131 @@
+/**
+ * @file TypeScript type definitions for Vento TOC and heading anchor plugins.
+ * @author Rick Cogley
+ */
+
+/**
+ * A single node in the table of contents tree.
+ */
+export interface TOCNode {
+  /** Heading level (2-6) */
+  level: number;
+
+  /** Text content of the heading */
+  text: string;
+
+  /** URL-safe slug generated from heading text */
+  slug: string;
+
+  /** Full URL to the heading (includes page URL + #slug) */
+  url: string;
+
+  /** Nested child headings */
+  children: TOCNode[];
+}
+
+/**
+ * Options for the heading anchors processor.
+ */
+export interface HeadingAnchorsOptions {
+  /**
+   * Minimum heading level to process (e.g., 2 for h2 and below)
+   * @default 2
+   */
+  level?: number;
+
+  /**
+   * Maximum heading level to process (e.g., 4 for up to h4)
+   * @default 6
+   */
+  maxLevel?: number;
+
+  /**
+   * Value of the tabindex attribute on headings, set to false to disable
+   * @default -1
+   */
+  tabIndex?: number | false;
+
+  /**
+   * Position of the anchor link relative to heading
+   * - "inside": Wrap heading text in anchor link
+   * - "outside": Place anchor link after heading text
+   * @default "outside"
+   */
+  anchorPosition?: "inside" | "outside";
+
+  /**
+   * CSS class to add to anchor links
+   * @default "header-anchor"
+   */
+  anchorClass?: string;
+
+  /**
+   * Symbol to use for anchor link
+   * @default "#"
+   */
+  anchorSymbol?: string;
+
+  /**
+   * aria-label text for anchor links (for accessibility)
+   * @default "Permalink"
+   */
+  ariaLabel?: string;
+
+  /**
+   * Only process pages using these template engines
+   * @default ["vto"]
+   */
+  includeTemplateEngines?: string[];
+
+  /**
+   * Custom slugify function
+   * If not provided, uses Lume's built-in slugifier
+   */
+  slugify?: (text: string) => string;
+}
+
+/**
+ * Options for the TOC generator processor.
+ */
+export interface TOCGeneratorOptions {
+  /**
+   * Minimum heading level to include in TOC
+   * @default 2
+   */
+  level?: number;
+
+  /**
+   * Maximum heading level to include in TOC
+   * @default 6
+   */
+  maxLevel?: number;
+
+  /**
+   * Key in page.data where TOC will be stored
+   * @default "toc"
+   */
+  key?: string;
+
+  /**
+   * Only process pages using these template engines
+   * @default ["vto"]
+   */
+  includeTemplateEngines?: string[];
+}
+
+/**
+ * Internal heading data structure used during processing.
+ */
+export interface HeadingData {
+  /** Heading level (2-6) */
+  level: number;
+
+  /** Text content */
+  text: string;
+
+  /** Generated slug */
+  slug: string;
+
+  /** DOM element reference */
+  element: Element;
+}

--- a/utils/headings.ts
+++ b/utils/headings.ts
@@ -1,0 +1,93 @@
+/**
+ * @file Utilities for extracting and processing heading elements from HTML.
+ * @author Rick Cogley
+ */
+
+import type { HeadingData } from "../types/vento_toc.ts";
+
+/**
+ * Extracts heading elements from a document.
+ *
+ * @param document - The DOM document to extract headings from
+ * @param minLevel - Minimum heading level to include (default: 2)
+ * @param maxLevel - Maximum heading level to include (default: 6)
+ * @returns Array of heading elements
+ *
+ * @example
+ * ```ts
+ * const headings = extractHeadingElements(page.document, 2, 4);
+ * // Returns all h2, h3, h4 elements
+ * ```
+ */
+export function extractHeadingElements(
+  document: Document,
+  minLevel = 2,
+  maxLevel = 6,
+): Element[] {
+  // Generate selector for heading levels (e.g., "h2, h3, h4")
+  const levels: string[] = [];
+  for (let i = minLevel; i <= maxLevel; i++) {
+    levels.push(`h${i}`);
+  }
+  const selector = levels.join(", ");
+
+  return Array.from(document.querySelectorAll(selector));
+}
+
+/**
+ * Extracts text content from a heading element, stripping HTML tags.
+ *
+ * @param element - The heading element
+ * @returns Plain text content
+ *
+ * @example
+ * ```ts
+ * const heading = document.querySelector("h2");
+ * const text = getHeadingText(heading);
+ * // Returns plain text without HTML tags
+ * ```
+ */
+export function getHeadingText(element: Element): string {
+  // Get text content, which automatically strips HTML
+  return element.textContent?.trim() || "";
+}
+
+/**
+ * Gets the heading level from an element's tag name.
+ *
+ * @param element - The heading element
+ * @returns Heading level (2-6)
+ *
+ * @example
+ * ```ts
+ * const h2 = document.querySelector("h2");
+ * getHeadingLevel(h2); // 2
+ * ```
+ */
+export function getHeadingLevel(element: Element): number {
+  const tagName = element.tagName.toLowerCase();
+  return parseInt(tagName.substring(1), 10);
+}
+
+/**
+ * Extracts heading data from elements.
+ *
+ * @param elements - Array of heading elements
+ * @param slugify - Function to generate slugs from text
+ * @returns Array of heading data objects
+ */
+export function extractHeadingData(
+  elements: Element[],
+  slugify: (text: string) => string,
+): HeadingData[] {
+  return elements.map((element) => ({
+    level: getHeadingLevel(element),
+    text: getHeadingText(element),
+    slug: "", // Will be filled in by slug generator
+    element,
+  })).map((heading, _index, allHeadings) => {
+    // Generate slug from text
+    heading.slug = slugify(heading.text);
+    return heading;
+  });
+}

--- a/utils/headings.ts
+++ b/utils/headings.ts
@@ -6,32 +6,49 @@
 import type { HeadingData } from "../types/vento_toc.ts";
 
 /**
- * Extracts heading elements from a document.
+ * Extracts heading elements from a document or container.
  *
  * @param document - The DOM document to extract headings from
  * @param minLevel - Minimum heading level to include (default: 2)
  * @param maxLevel - Maximum heading level to include (default: 6)
+ * @param containerSelector - Optional CSS selector to limit extraction scope (e.g., "article", "#main-content")
  * @returns Array of heading elements
  *
  * @example
  * ```ts
+ * // Extract all h2-h4 from entire document
  * const headings = extractHeadingElements(page.document, 2, 4);
- * // Returns all h2, h3, h4 elements
+ *
+ * // Extract only from main content area
+ * const contentHeadings = extractHeadingElements(page.document, 2, 4, "article");
  * ```
  */
 export function extractHeadingElements(
   document: Document,
   minLevel = 2,
   maxLevel = 6,
+  containerSelector?: string,
 ): Element[] {
   // Generate selector for heading levels (e.g., "h2, h3, h4")
   const levels: string[] = [];
   for (let i = minLevel; i <= maxLevel; i++) {
     levels.push(`h${i}`);
   }
-  const selector = levels.join(", ");
+  const headingSelector = levels.join(", ");
 
-  return Array.from(document.querySelectorAll(selector));
+  // If container selector provided, scope to that container
+  if (containerSelector) {
+    const container = document.querySelector(containerSelector);
+    if (!container) {
+      console.warn(
+        `⚠️  extractHeadingElements: Container "${containerSelector}" not found`,
+      );
+      return [];
+    }
+    return Array.from(container.querySelectorAll(headingSelector));
+  }
+
+  return Array.from(document.querySelectorAll(headingSelector));
 }
 
 /**

--- a/utils/slugify.ts
+++ b/utils/slugify.ts
@@ -1,0 +1,86 @@
+/**
+ * @file Simple slug generation utility for headings.
+ * @author Rick Cogley
+ */
+
+/**
+ * Converts text to a URL-safe slug.
+ *
+ * This is a simplified slugifier that:
+ * - Converts to lowercase
+ * - Removes HTML tags
+ * - Replaces non-alphanumeric characters with hyphens
+ * - Removes leading/trailing hyphens
+ * - Collapses multiple hyphens
+ *
+ * @param text - The text to slugify
+ * @returns A URL-safe slug
+ *
+ * @example
+ * ```ts
+ * slugify("Hello World!"); // "hello-world"
+ * slugify("Table of Contents"); // "table-of-contents"
+ * slugify("What's New?"); // "whats-new"
+ * ```
+ */
+export function slugify(text: string): string {
+  return text
+    .toString()
+    .toLowerCase()
+    // Remove HTML tags
+    .replace(/<[^>]+>/g, "")
+    // Replace spaces and special chars with hyphens
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_-]+/g, "-")
+    // Remove leading/trailing hyphens
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Generates unique slugs by appending numbers when duplicates are found.
+ *
+ * @example
+ * ```ts
+ * const generator = new UniqueSlugGenerator();
+ * generator.generate("intro"); // "intro"
+ * generator.generate("intro"); // "intro-1"
+ * generator.generate("intro"); // "intro-2"
+ * ```
+ */
+export class UniqueSlugGenerator {
+  private slugs = new Set<string>();
+
+  /**
+   * Generate a unique slug, appending a number if the slug already exists.
+   *
+   * @param text - The text to slugify
+   * @returns A unique slug
+   */
+  generate(text: string): string {
+    let slug = slugify(text);
+
+    // If slug is empty, use a default
+    if (!slug) {
+      slug = "heading";
+    }
+
+    // Make it unique by appending numbers
+    let uniqueSlug = slug;
+    let counter = 1;
+
+    while (this.slugs.has(uniqueSlug)) {
+      uniqueSlug = `${slug}-${counter}`;
+      counter++;
+    }
+
+    this.slugs.add(uniqueSlug);
+    return uniqueSlug;
+  }
+
+  /**
+   * Clear all generated slugs (useful for processing multiple pages).
+   */
+  clear(): void {
+    this.slugs.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive table of contents (TOC) and heading anchor support for pure Vento (.vto) pages, matching the functionality that markdown-it plugins provide for markdown pages.

## New Features

### Processors (3 new)

1. **`ventoHeadingAnchors`** - Add ID attributes and anchor links to headings
   - Automatic unique slug generation with collision prevention
   - Configurable heading levels (min/max) and anchor positioning
   - Matches markdown-it-toc-done-right behavior by default
   - Supports `containerSelector` option to limit scope to main content

2. **`ventoTOC`** - Generate hierarchical table of contents data
   - Builds nested TOC tree structure stored in `page.data.toc`
   - Generates full URLs with anchors for each heading
   - Supports `containerSelector` option for scoped extraction

3. **`ventoTOCInject`** - Inject TOC HTML into rendered pages
   - Works around Lume's build order limitation (processors run after layouts)
   - Finds `<!-- VENTO-TOC-INJECTION-POINT: -->` marker and replaces with TOC HTML
   - Respects `show_toc` frontmatter setting

### Utilities (3 new modules)

- `utils/slugify.ts` - URL-safe slug generation from text
- `utils/headings.ts` - Heading extraction and manipulation utilities
- `types/vento_toc.ts` - TypeScript types for TOC functionality

## Changes

- **Default behavior**: `ventoHeadingAnchors` now matches markdown-it style
  - `anchorPosition: "inside"` (anchor wraps heading text)
  - `anchorSymbol: ""` (empty - use CSS ::before for icon)
  - Ensures consistent appearance between Vento and markdown pages

## Bug Fixes

- Prevent duplicate anchors/TOC on markdown pages by skipping pages with "md" in templateEngine chain
- Only pure Vento pages (templateEngine: ["vto"]) are processed by Vento processors

## Documentation

- Comprehensive documentation for all three processors in README
- Complete workflow examples showing proper processor ordering
- CSS styling examples for anchor links
- Explanation of Lume build order and HTML injection solution
- New RELEASE_GUIDE.md with step-by-step release process

## Release Preparation

- [x] Version updated to 1.3.0 in all files (deno.json, mod.ts, README.md)
- [x] CHANGELOG.md updated with detailed release notes
- [x] API documentation regenerated (87 files in docs/api/)
- [x] Type errors fixed in new code
- [x] Lint warnings fixed in new code
- [x] Code formatted with deno fmt

## Testing

New processors have been tested in production. Pre-existing test failures in older preprocessors are tracked in #3.

## Breaking Changes

None - this is a minor version release adding new features.

## Commits

- feat: add Vento heading anchors and TOC generators
- feat: change ventoHeadingAnchors defaults to match markdown-it style
- fix: prevent duplicate anchors/TOC on markdown pages
- feat: add HTML injection processor and containerSelector option
- docs: add comprehensive documentation for Vento TOC processors

## Related Issues

- Addresses need for TOC functionality in pure Vento pages
- Pre-existing issues tracked in #3 (not blockers)

---

**Ready to merge** after review. After merge, create GitHub release with tag `v1.3.0` to trigger webhook publication to deno.land/x.