### PR TITLE
feat(suite): add .esolia/system.json suite descriptor

### DIFF
--- a/.esolia/system.json
+++ b/.esolia/system.json
@@ -1,0 +1,20 @@
+{
+  "name": "hibana",
+  "purpose": "Library of Lume plugins, processors, filters, and helper functions for enhancing Lume static-site-generation projects.",
+  "repo": "RickCogley/hibana",
+  "audience": "public",
+  "stack": ["deno", "typescript", "lume"],
+  "owners": ["RickCogley"],
+  "status": "active",
+  "sensitivity": {
+    "overview": "org",
+    "topology": "dev",
+    "security": "dev"
+  },
+  "exposes": [
+    { "name": "Lume helpers", "kind": "library" }
+  ],
+  "links": {
+    "docs": "https://hibana-docs.esolia.workers.dev/"
+  }
+}


### PR DESCRIPTION
## Summary

Adds this repo's `.esolia/system.json` so it appears in the eSolia suite-context map served by the Standards MCP. Harvested read-only by eSolia/devkit's aggregator (now includes shared-infrastructure repos via `SUITE_INFRA_REPOS`); this descriptor upgrades the entry from inferred to declared.

## Test plan

- [x] Validates against devkit's `.esolia/system.schema.json` (ajv + ajv-formats).
- [x] `deno fmt --check` clean.
- [x] Non-secret metadata only.

Closes #24

InfoSec: no security impact — additive non-secret descriptor; no code or runtime change.
